### PR TITLE
add detection for 4-digit codes at beginning of msg (e.g. Microsoft)

### DIFF
--- a/find-messages.php
+++ b/find-messages.php
@@ -118,8 +118,8 @@ while ($message = $query->fetch(PDO::FETCH_ASSOC)) {
         //   "Your code is 45678!"
         //   "Your code is:98765!"
         $code = $matches[2];
-    } elseif (preg_match('/^(\d{4})(\sis your.*code)/', $text, $matches)) {
-        // 4 digits followed by "is your [...] code"
+    } elseif (preg_match('/^(\d{4,8})(\sis your.*code)/', $text, $matches)) {
+        // 4-8 digits followed by "is your [...] code"
         // examples:
         //   "2773 is your Microsoft account verification code"
         $code = $matches[1];

--- a/find-messages.php
+++ b/find-messages.php
@@ -118,6 +118,11 @@ while ($message = $query->fetch(PDO::FETCH_ASSOC)) {
         //   "Your code is 45678!"
         //   "Your code is:98765!"
         $code = $matches[2];
+    } elseif (preg_match('/^(\d{4})(\sis your.*code)/', $text, $matches)) {
+        // 4 digits followed by "is your [...] code"
+        // examples:
+        //   "2773 is your Microsoft account verification code"
+        $code = $matches[1];
     } elseif (preg_match('/(code:|is:)\s*(\d{4,8})($|\s|\R|\t|\b|\.|,)/i', $text, $matches)) {
         // "code:" OR "is:", optional whitespace, then 4-8 consecutive digits
         // examples:


### PR DESCRIPTION
simple patch to add detection for messages like this:

![image](https://user-images.githubusercontent.com/1992842/135174823-ac4cfaf6-b353-4ff0-85c6-da605d02a081.png)
